### PR TITLE
Use TrimSuffix substitute TrimRight

### DIFF
--- a/main.go
+++ b/main.go
@@ -100,7 +100,7 @@ func getOwnerRepo() (*Repo, error) {
 
 func parserRemote(remote string) (*Repo, error) {
 	if strings.HasSuffix(remote, ".git") {
-		remote = strings.TrimRight(remote, ".git")
+		remote = strings.TrimSuffix(remote, ".git")
 	}
 	var ownerRepo []string
 	if strings.HasPrefix(remote, "ssh") {


### PR DESCRIPTION
TrimRight does not work properly on repositories ending in ["g", "i", "t"] because it deletes strings character by character, not string. 

### Reproduction
- https://go.dev/play/p/YWdxXQ-gi75