### PR TITLE
Replace io/ioutil with os package

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -39,7 +38,7 @@ func getToken() (string, error) {
 		}
 
 		configFile := filepath.Join(homeDir, configFile)
-		b, err := ioutil.ReadFile(configFile)
+		b, err := os.ReadFile(configFile)
 		if err != nil {
 			return "", err
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -106,7 +105,7 @@ func TestGetToken(t *testing.T) {
 			os.Remove(configFile)
 		})
 
-		if err := ioutil.WriteFile(configFile, []byte("a\n"), 0777); err != nil {
+		if err := os.WriteFile(configFile, []byte("a\n"), 0777); err != nil {
 			t.Fatalf("got error: %s", err)
 		}
 


### PR DESCRIPTION
io/ioutil package has been deprecated. (https://go.dev/doc/go1.16#ioutil)